### PR TITLE
Do not depend explicitly on pycares

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiodns==1.0.0
 bencodepy==0.9.5
-pycares==1.0.0


### PR DESCRIPTION
pycares is never invoked directly, and aiodns already depends on pycares>=1.0.0
Pinning pycares to 1.0.0 is unnecessary.
